### PR TITLE
Create wrapper for fclose so it can be passed to LT_PUSH as lt_destroy_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SOURCE_FILES
   src/system/error.c
   src/system/lt.c
   src/system/lt/lt_slot.c
+  src/system/lt/lt_adapters.c
 )
 
 set(HEADER_FILES
@@ -71,6 +72,7 @@ set(HEADER_FILES
   src/system/error.h
   src/system/lt.h
   src/system/lt/lt_slot.h
+  src/system/lt/lt_adapters.h
 )
 
 add_executable(nothing ${SOURCE_FILES} ${HEADER_FILES})

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -27,6 +27,12 @@ struct level_t
     boxes_t *boxes;
 };
 
+// A wrapper for fclose to pass like lt_destroy_t
+static void fclose_lt(void* file)
+{
+    fclose(file);
+}
+
 level_t *create_level_from_file(const char *file_name)
 {
     assert(file_name);
@@ -42,7 +48,7 @@ level_t *create_level_from_file(const char *file_name)
         RETURN_LT(lt, NULL);
     }
 
-    FILE *level_file = PUSH_LT(lt, fopen(file_name, "r"), fclose);
+    FILE *level_file = PUSH_LT(lt, fopen(file_name, "r"), fclose_lt);
     if (level_file == NULL) {
         throw_error(ERROR_TYPE_LIBC);
         RETURN_LT(lt, NULL);
@@ -243,7 +249,7 @@ int level_reload_preserve_player(level_t *level, const char *file_name)
 
     /* TODO(#104): duplicate code in create_level_from_file and level_reload_preserve_player */
 
-    FILE * const level_file = PUSH_LT(lt, fopen(file_name, "r"), fclose);
+    FILE * const level_file = PUSH_LT(lt, fopen(file_name, "r"), fclose_lt);
     if (level_file == NULL) {
         throw_error(ERROR_TYPE_LIBC);
         RETURN_LT(lt, -1);

--- a/src/game/level.c
+++ b/src/game/level.c
@@ -11,6 +11,7 @@
 #include "game/level/player.h"
 #include "system/error.h"
 #include "system/lt.h"
+#include "system/lt/lt_adapters.h"
 
 #define LEVEL_GRAVITY 1500.0f
 
@@ -26,12 +27,6 @@ struct level_t
     background_t *background;
     boxes_t *boxes;
 };
-
-// A wrapper for fclose to pass like lt_destroy_t
-static void fclose_lt(void* file)
-{
-    fclose(file);
-}
 
 level_t *create_level_from_file(const char *file_name)
 {

--- a/src/game/level/platforms.c
+++ b/src/game/level/platforms.c
@@ -7,6 +7,7 @@
 #include "platforms.h"
 #include "system/error.h"
 #include "system/lt.h"
+#include "system/lt/lt_adapters.h"
 
 struct platforms_t {
     lt_t *lt;
@@ -15,12 +16,6 @@ struct platforms_t {
     color_t *colors;
     size_t rects_size;
 };
-
-// A wrapper for fclose to pass like lt_destroy_t
-static void fclose_lt(void* file)
-{
-    fclose(file);
-}
 
 platforms_t *create_platforms_from_stream(FILE *stream)
 {

--- a/src/game/level/platforms.c
+++ b/src/game/level/platforms.c
@@ -16,6 +16,12 @@ struct platforms_t {
     size_t rects_size;
 };
 
+// A wrapper for fclose to pass like lt_destroy_t
+static void fclose_lt(void* file)
+{
+    fclose(file);
+}
+
 platforms_t *create_platforms_from_stream(FILE *stream)
 {
     assert(stream);
@@ -103,7 +109,7 @@ int platforms_save_to_file(const platforms_t *platforms,
         return -1;
     }
 
-    FILE *platforms_file = PUSH_LT(lt, fopen(filename, "w"), fclose);
+    FILE *platforms_file = PUSH_LT(lt, fopen(filename, "w"), fclose_lt);
 
     if (platforms_file == NULL) {
         throw_error(ERROR_TYPE_LIBC);

--- a/src/system/lt/lt_adapters.c
+++ b/src/system/lt/lt_adapters.c
@@ -1,0 +1,7 @@
+#include "lt_adapters.h"
+#include <stdio.h>
+
+void fclose_lt(void* file)
+{
+    fclose(file);
+}

--- a/src/system/lt/lt_adapters.h
+++ b/src/system/lt/lt_adapters.h
@@ -1,0 +1,6 @@
+#ifndef LT_ADAPTERS_H_
+#define LT_ADAPTERS_H_
+
+void fclose_lt(void* file);
+
+#endif  // LT_ADAPTERS_H_


### PR DESCRIPTION
Fix for #208 

Created a wrapper `fclose_lt` for `fclose` in _level.c_ and _platforms.c_ so it can be passed to `LT_PUSH` as `lt_destroy_t`. 

Seems like newer GCC's `-Werror` is more aggressive and didn't allow simply passing `fclose` to `LT_PUSH`.

Since they are duplicated, maybe they can be extracted into some header file. But I didn't wanna change the structure of the project. 