### PR TITLE
Fix #404

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -242,9 +242,13 @@ static int game_event_running(Game *game, const SDL_Event *event)
             camera_toggle_debug_mode(game->camera);
             level_toggle_debug_mode(game->level);
             break;
-
+        }
+        break;
+    case SDL_KEYUP:
+        switch (event->key.keysym.sym) {
         case SDLK_BACKQUOTE:
         case SDLK_c:
+            SDL_StartTextInput();
             game->state = GAME_STATE_CONSOLE;
             /* TODO(#404): when console is enabled a backquote pressed event sneaks into edit_field a gets inserted */
             console_slide_down(game->console);
@@ -267,6 +271,7 @@ static int game_event_console(Game *game, const SDL_Event *event)
     case SDL_KEYDOWN:
         switch (event->key.keysym.sym) {
         case SDLK_ESCAPE:
+            SDL_StopTextInput();
             game->state = GAME_STATE_RUNNING;
             return 0;
 

--- a/src/game.c
+++ b/src/game.c
@@ -250,7 +250,6 @@ static int game_event_running(Game *game, const SDL_Event *event)
         case SDLK_c:
             SDL_StartTextInput();
             game->state = GAME_STATE_CONSOLE;
-            /* TODO(#404): when console is enabled a backquote pressed event sneaks into edit_field a gets inserted */
             console_slide_down(game->console);
             break;
         }

--- a/src/main.c
+++ b/src/main.c
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
 
     const Uint8 *const keyboard_state = SDL_GetKeyboardState(NULL);
 
-    SDL_StartTextInput();
+    SDL_StopTextInput();
     SDL_Event e;
     const int64_t delta_time = (int64_t) roundf(1000.0f / 60.0f);
     int64_t render_timer = (int64_t) roundf(1000.0f / (float) fps);


### PR DESCRIPTION
Fixes #404.
You might wonder why I disabled textinput in `main.c`. There are two reasons actually:
1) On most desktop systems textinput is enabled by default. So textinput events will be spamming even without it. Check couple relevant discussions: [one](https://discourse.libsdl.org/t/confused-on-how-to-handle-or-why-sdl-starttextinput/19857/15), [two](https://discourse.libsdl.org/t/is-it-normal-to-get-sdl-textediting-events-w-o-sdl-starttext/21240)
2) Best practices tell us that you should enable textinput events only when you need them. That's why I enable them when in `GAME_STATE_CONSOLE` and disable otherwise.

What do you think? Does it makes sense?