### PR TITLE
Added support for creating lambdas usign λ symbol

### DIFF
--- a/src/ebisp/builtins.c
+++ b/src/ebisp/builtins.c
@@ -130,7 +130,7 @@ bool lambda_p(struct Expr obj)
         return false;
     }
 
-    if (strcmp("lambda", obj.cons->car.atom->sym) != 0) {
+    if (!is_lambda(obj.cons)) {
         return false;
     }
 
@@ -183,4 +183,9 @@ struct Expr list(Gc *gc, size_t n, ...)
     struct Expr obj = list_rec(gc, n, args);
     va_end(args);
     return obj;
+}
+
+bool is_lambda(struct Cons *cons) {
+    return (strcmp(cons->car.atom->sym, "lambda") == 0) ||
+            (strcmp(cons->car.atom->sym, "λ") == 0);
 }

--- a/src/ebisp/builtins.h
+++ b/src/ebisp/builtins.h
@@ -13,6 +13,7 @@ bool cons_p(struct Expr obj);
 bool list_p(struct Expr obj);
 bool list_of_symbols_p(struct Expr obj);
 bool lambda_p(struct Expr obj);
+bool is_lambda(struct Cons *cons);
 
 long int length_of_list(struct Expr obj);
 

--- a/src/ebisp/interpreter.c
+++ b/src/ebisp/interpreter.c
@@ -2,6 +2,7 @@
 #include <math.h>
 #include <string.h>
 #include <stdarg.h>
+#include <stdbool.h>
 
 #include "./builtins.h"
 #include "./expr.h"
@@ -271,7 +272,7 @@ static struct EvalResult eval_funcall(Gc *gc, struct Scope *scope, struct Cons *
             return eval_success(cons->cdr.cons->car);
         } else if (strcmp(cons->car.atom->sym, "begin") == 0) {
             return eval_block(gc, scope, CDR(cons_as_expr(cons)));
-        } else if (strcmp(cons->car.atom->sym, "lambda") == 0) {
+        } else if (is_lambda(cons)) {
             /* TODO(#335): lambda special form doesn't check if it forms a callable object */
             return eval_success(cons_as_expr(cons));
         } else if (strcmp(cons->car.atom->sym, "when") == 0) {


### PR DESCRIPTION
Updated ebisp to add lambda character support

```lisp
> (set fn (lambda () 't))
't
; is equivalent to
> (set fn (λ () 't))
't
```