### PR TITLE
Remove superfluous "defun" in specials

### DIFF
--- a/src/ebisp/builtins.c
+++ b/src/ebisp/builtins.c
@@ -175,7 +175,7 @@ bool is_lambda(struct Cons *cons) {
 const char *specials[] = {
     "set", "quote", "begin",
     "defun", "lambda", "λ",
-    "defun", "when", "quasiquote"
+    "when", "quasiquote"
 };
 
 bool is_special(const char *name)


### PR DESCRIPTION
`"defun"` appeared twice in `const char *specials[]`