### PR TITLE
(#882) Make the Platform level loadable

### DIFF
--- a/src/ebisp/parser.c
+++ b/src/ebisp/parser.c
@@ -216,6 +216,10 @@ struct ParseResult read_all_exprs_from_string(Gc *gc, const char *str)
     trace_assert(str);
 
     struct Token current_token = next_token(str);
+    if (*current_token.end == 0) {
+        return parse_success(NIL(gc), current_token.end);
+    }
+
     struct ParseResult parse_result = parse_expr(gc, current_token);
     if (parse_result.is_error) {
         return parse_result;

--- a/src/system/line_stream.c
+++ b/src/system/line_stream.c
@@ -103,7 +103,7 @@ const char *line_stream_next(LineStream *line_stream)
 
 char *line_stream_collect_n_lines(LineStream *line_stream, size_t n)
 {
-    char *result = NULL;
+    char *result = string_append(NULL, "");
     for (size_t i = 0; i < n; ++i) {
         const char *line = line_stream_next(line_stream);
         if (line == NULL) {

--- a/test/parser_suite.h
+++ b/test/parser_suite.h
@@ -82,10 +82,18 @@ TEST(read_all_exprs_from_string_empty_test)
     Gc *gc = create_gc();
     struct ParseResult result = read_all_exprs_from_string(gc, "");
 
-    ASSERT_TRUE(result.is_error, {
+    ASSERT_FALSE(result.is_error, {
             fprintf(stderr,
-                    "Parsing is expected to fail, "
-                    "but it did not\n");
+                    "Parsing was unsuccessful: %s\n",
+                    result.error_message);
+    });
+
+    ASSERT_EQ(long int, 0, length_of_list(result.expr), {
+            fprintf(stderr, "Expected: %ld\n", _expected);
+            fprintf(stderr, "Actual: %ld\n", _actual);
+            fprintf(stderr, "Expression: ");
+            print_expr_as_sexpr(stderr, result.expr);
+            fprintf(stderr, "\n");
     });
 
     destroy_gc(gc);


### PR DESCRIPTION
1. line_stream_collect_n_lines returned NULL on n == 0 which is not
correct. It's way better when it returns an empty string
2. read_all_exprs_from_string returned parse error on empty input
which is also not correct. It's better to return nil.

Close #882 