### PR TITLE
Make build with MSVC compiler strict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,10 +214,12 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     "${CMAKE_C_FLAGS} \
     /Wall \
     /WX \
+    /wd4127 \
     /wd4201 \
     /wd4204 \
     /wd4255 \
     /wd4668 \
+    /wd4702 \
     /wd4710 \
     /wd4777 \
     /wd4820 \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,20 @@ if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" ST
      -ggdb \
      -O3")
   target_link_libraries(nothing m)
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  set(CMAKE_C_FLAGS
+    "${CMAKE_C_FLAGS} \
+    /Wall \
+    /WX \
+    /wd4201 \
+    /wd4204 \
+    /wd4255 \
+    /wd4668 \
+    /wd4710 \
+    /wd4777 \
+    /wd4820 \
+    /wd5045 \
+    /D \"_CRT_SECURE_NO_WARNINGS\"")
 endif()
 if(WIN32)
   target_link_libraries(nothing Imm32 Version winmm)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     /wd4201 \
     /wd4204 \
     /wd4255 \
+    /wd4389 \
     /wd4668 \
     /wd4702 \
     /wd4710 \

--- a/src/ebisp/gc.c
+++ b/src/ebisp/gc.c
@@ -1,6 +1,7 @@
 #include "system/stacktrace.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 
 #include "builtins.h"

--- a/src/ebisp/gc.c
+++ b/src/ebisp/gc.c
@@ -19,12 +19,12 @@ struct Gc
     size_t capacity;
 };
 
-static long int value_of_expr(struct Expr expr)
+static intptr_t value_of_expr(struct Expr expr)
 {
     if (expr.type == EXPR_CONS) {
-        return (long int) expr.cons;
+        return (intptr_t) expr.cons;
     } else if (expr.type == EXPR_ATOM) {
-        return (long int) expr.atom;
+        return (intptr_t) expr.atom;
     } else {
         return 0;
     }
@@ -35,9 +35,9 @@ static int compare_exprs(const void *a, const void *b)
     trace_assert(a);
     trace_assert(b);
 
-    const long int ptr_a = value_of_expr(*(const struct Expr *)a);
-    const long int ptr_b = value_of_expr(*(const struct Expr *)b);
-    const long int d = ptr_b - ptr_a;
+    const intptr_t ptr_a = value_of_expr(*(const struct Expr *)a);
+    const intptr_t ptr_b = value_of_expr(*(const struct Expr *)b);
+    const intptr_t d = ptr_b - ptr_a;
 
     if (d < 0) {
         return -1;

--- a/src/ebisp/parser.c
+++ b/src/ebisp/parser.c
@@ -122,7 +122,7 @@ static struct ParseResult parse_string(Gc *gc, struct Token current_token)
 static struct ParseResult parse_number(Gc *gc, struct Token current_token)
 {
     char *endptr = 0;
-    const long int x = strtoimax(current_token.begin, &endptr, 10);
+    const long int x = strtol(current_token.begin, &endptr, 10);
 
     if (current_token.begin == endptr || current_token.end != endptr) {
         return parse_failure("Expected number", current_token.begin);

--- a/src/game/level/goals.c
+++ b/src/game/level/goals.c
@@ -53,7 +53,7 @@ Goals *create_goals_from_line_stream(LineStream *line_stream)
     goals->count = 0;
     if (sscanf(
             line_stream_next(line_stream),
-            "%lu",
+            "%zu",
             &goals->count) == EOF) {
         log_fail("Could not read amount of goals\n");
         RETURN_LT(lt, NULL);

--- a/src/game/level/labels.c
+++ b/src/game/level/labels.c
@@ -51,7 +51,7 @@ Labels *create_labels_from_line_stream(LineStream *line_stream)
 
     if (sscanf(
             line_stream_next(line_stream),
-            "%lu",
+            "%zu",
             &labels->count) == EOF) {
         log_fail("Could not read amount of labels\n");
         RETURN_LT(lt, NULL);

--- a/src/game/level/lava.c
+++ b/src/game/level/lava.c
@@ -33,7 +33,7 @@ Lava *create_lava_from_line_stream(LineStream *line_stream)
 
     if (sscanf(
             line_stream_next(line_stream),
-            "%lu",
+            "%zu",
             &lava->rects_count) < 0) {
         log_fail("Could not read amount of lava\n");
         RETURN_LT(lt, NULL);

--- a/src/game/level/level_editor.c
+++ b/src/game/level/level_editor.c
@@ -308,7 +308,7 @@ int level_editor_render(const LevelEditor *level_editor,
         return -1;
     }
 
-    for (int i = 0; i < LAYER_PICKER_N; ++i) {
+    for (size_t i = 0; i < LAYER_PICKER_N; ++i) {
         if (layer_render(
                 level_editor->layers[i],
                 camera,

--- a/src/game/level/level_editor.c
+++ b/src/game/level/level_editor.c
@@ -308,7 +308,7 @@ int level_editor_render(const LevelEditor *level_editor,
         return -1;
     }
 
-    for (size_t i = 0; i < LAYER_PICKER_N; ++i) {
+    for (int i = 0; i < LAYER_PICKER_N; ++i) {
         if (layer_render(
                 level_editor->layers[i],
                 camera,

--- a/src/game/level/level_editor/label_layer.c
+++ b/src/game/level/level_editor/label_layer.c
@@ -86,7 +86,7 @@ LabelLayer *create_label_layer_from_line_stream(LineStream *line_stream)
     }
 
     size_t n = 0;
-    if (sscanf(line, "%lu", &n) == EOF) {
+    if (sscanf(line, "%zu", &n) == EOF) {
         log_fail("Could not parse amount of labels\n");
         RETURN_LT(label_layer->lt, NULL);
     }
@@ -211,7 +211,7 @@ int label_layer_dump_stream(const LabelLayer *label_layer, FILE *filedump)
     Color *colors = dynarray_data(label_layer->colors);
     char **texts = dynarray_data(label_layer->texts);
 
-    fprintf(filedump, "%ld\n", n);
+    fprintf(filedump, "%zd\n", n);
     for (size_t i = 0; i < n; ++i) {
         fprintf(filedump, "%s %f %f ",
                 ids + LABEL_LAYER_ID_MAX_SIZE * i,

--- a/src/game/level/level_editor/layer_picker.c
+++ b/src/game/level/level_editor/layer_picker.c
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include <string.h>
 
 #include <SDL.h>
 

--- a/src/game/level/level_editor/layer_picker.c
+++ b/src/game/level/level_editor/layer_picker.c
@@ -73,7 +73,7 @@ int layer_picker_render(const LayerPicker *layer_picker,
     trace_assert(layer_picker);
     trace_assert(camera);
 
-    for (int i = 0; i < LAYER_PICKER_N; ++i) {
+    for (size_t i = 0; i < LAYER_PICKER_N; ++i) {
         Vec position = layer_picker_position(camera);
         Color color = LAYER_CELL_BACKGROUND_COLORS[i];
 

--- a/src/game/level/level_editor/layer_picker.c
+++ b/src/game/level/level_editor/layer_picker.c
@@ -73,7 +73,7 @@ int layer_picker_render(const LayerPicker *layer_picker,
     trace_assert(layer_picker);
     trace_assert(camera);
 
-    for (size_t i = 0; i < LAYER_PICKER_N; ++i) {
+    for (int i = 0; i < LAYER_PICKER_N; ++i) {
         Vec position = layer_picker_position(camera);
         Color color = LAYER_CELL_BACKGROUND_COLORS[i];
 

--- a/src/game/level/level_editor/point_layer.c
+++ b/src/game/level/level_editor/point_layer.c
@@ -92,7 +92,7 @@ PointLayer *create_point_layer_from_line_stream(LineStream *line_stream)
     size_t count = 0;
     if (sscanf(
             line_stream_next(line_stream),
-            "%lu",
+            "%zu",
             &count) == EOF) {
         log_fail("Could not read amount of points");
         RETURN_LT(point_layer->lt, NULL);
@@ -382,7 +382,7 @@ int point_layer_dump_stream(const PointLayer *point_layer,
     Point *points = dynarray_data(point_layer->points);
     Color *colors = dynarray_data(point_layer->colors);
 
-    fprintf(filedump, "%ld\n", n);
+    fprintf(filedump, "%zd\n", n);
     for (size_t i = 0; i < n; ++i) {
         fprintf(filedump, "%s %f %f ",
                 ids + ID_MAX_SIZE * i,

--- a/src/game/level/level_editor/rect_layer.c
+++ b/src/game/level/level_editor/rect_layer.c
@@ -89,7 +89,7 @@ RectLayer *create_rect_layer_from_line_stream(LineStream *line_stream)
     }
 
     size_t count = 0;
-    if (sscanf(line, "%lu", &count) < 0) {
+    if (sscanf(line, "%zu", &count) < 0) {
         RETURN_LT(layer->lt, NULL);
     }
 
@@ -267,7 +267,7 @@ int rect_layer_dump_stream(const RectLayer *layer, FILE *filedump)
     Rect *rects = dynarray_data(layer->rects);
     Color *colors = dynarray_data(layer->colors);
 
-    fprintf(filedump, "%ld\n", n);
+    fprintf(filedump, "%zd\n", n);
     for (size_t i = 0; i < n; ++i) {
         fprintf(filedump, "%s %f %f %f %f ",
                 ids + RECT_LAYER_ID_MAX_SIZE * i,

--- a/src/game/level/regions.c
+++ b/src/game/level/regions.c
@@ -48,7 +48,7 @@ Regions *create_regions_from_line_stream(LineStream *line_stream)
 
     if(sscanf(
            line_stream_next(line_stream),
-           "%lu",
+           "%zu",
            &regions->count) < 0) {
         log_fail("Could not read amount of script regions\n");
         RETURN_LT(lt, NULL);

--- a/src/game/level/rigid_bodies.c
+++ b/src/game/level/rigid_bodies.c
@@ -270,7 +270,7 @@ int rigid_bodies_render(RigidBodies *rigid_bodies,
         return -1;
     }
 
-    snprintf(text_buffer, 256, "id: %ld", id);
+    snprintf(text_buffer, 256, "id: %zd", id);
 
     if (camera_render_debug_text(
             camera,

--- a/src/math/rect.c
+++ b/src/math/rect.c
@@ -105,7 +105,7 @@ Line rect_side(Rect rect, Rect_side side)
     const float x2 = rect.x + rect.w;
     const float y2 = rect.y + rect.h;
 
-    Line result;
+    Line result = { 0 };
 
     switch (side) {
     case RECT_SIDE_LEFT:

--- a/test/parser_suite.h
+++ b/test/parser_suite.h
@@ -175,7 +175,7 @@ TEST(read_all_exprs_from_string_trailing_spaces_test)
 
     ASSERT_FALSE(result.is_error, {
             fprintf(stderr, "Parsing failed: %s\n", result.error_message);
-            fprintf(stderr, "Position: %ld\n", result.end - source_code);
+            fprintf(stderr, "Position: %zd\n", result.end - source_code);
     });
 
     return 0;


### PR DESCRIPTION
One of the major changes is changing `%lx` to `%zx` for argument of type `size_t` (it was introduced in C99, according to [this](https://stackoverflow.com/a/2524675/1901561) post, sorry couldn't find it in the docs).

I also added the following two warnings to be ignored (aside from warnings, which were mentioned in #877):

- [C4127](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4127?view=vs-2019): conditional expression is constant, because of [this](https://github.com/tsoding/nothing/blob/master/src/sdl/renderer.c#L177) equation; and
- [C4702](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4702?view=vs-2019): unreachable code, because of [this](https://github.com/tsoding/nothing/blob/51d07e0b900942760f54089af710b874bb0a83cd/src/ebisp/repl_runtime.c#L28-L30).

Closes #877 and #865.