### PR TITLE
(#355) Add common Emacs keybindings to `Edit_field`

### DIFF
--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -48,7 +48,6 @@ struct Console
     char *eval_result;
 };
 
-/* TODO(#355): Console does not support Emacs keybindings */
 /* TODO(#356): Console does not support autocompletion */
 /* TODO(#357): Console does not show the state of the GC of the script */
 /* TODO(#358): Console does not support copy, cut, paste operations */

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -196,14 +196,14 @@ int console_handle_event(Console *console,
             history_prev(console->history);
             return 0;
 
-        case SDLK_p:
+        case SDLK_p: {
             if (event->key.keysym.mod & KMOD_CTRL) {
                 edit_field_replace(
                     console->edit_field, history_current(console->history));
                 history_prev(console->history);
                 return 0;
             }
-            break;
+        } break;
 
         case SDLK_DOWN:
             edit_field_replace(
@@ -212,14 +212,14 @@ int console_handle_event(Console *console,
             history_next(console->history);
             return 0;
 
-        case SDLK_n:
+        case SDLK_n: {
             if (event->key.keysym.mod & KMOD_CTRL) {
                 edit_field_replace(
                     console->edit_field, history_current(console->history));
                 history_next(console->history);
                 return 0;
             }
-            break;
+        } break;
         }
     } break;
     }

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -196,12 +196,30 @@ int console_handle_event(Console *console,
             history_prev(console->history);
             return 0;
 
+        case SDLK_p:
+            if (event->key.keysym.mod & KMOD_CTRL) {
+                edit_field_replace(
+                    console->edit_field, history_current(console->history));
+                history_prev(console->history);
+                return 0;
+            }
+            break;
+
         case SDLK_DOWN:
             edit_field_replace(
                 console->edit_field,
                 history_current(console->history));
             history_next(console->history);
             return 0;
+
+        case SDLK_n:
+            if (event->key.keysym.mod & KMOD_CTRL) {
+                edit_field_replace(
+                    console->edit_field, history_current(console->history));
+                history_next(console->history);
+                return 0;
+            }
+            break;
         }
     } break;
     }

--- a/src/ui/edit_field.c
+++ b/src/ui/edit_field.c
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include <string.h>
 
 #include "edit_field.h"
 #include "game/camera.h"
@@ -46,9 +47,8 @@ static void edit_field_insert_char(Edit_field *edit_field, char c)
         return;
     }
 
-    for (int64_t i = (int64_t) edit_field->buffer_size - 1; i >= (int64_t) edit_field->cursor; --i) {
-        edit_field->buffer[i + 1] = edit_field->buffer[i];
-    }
+    char *dest = edit_field->buffer + edit_field->cursor + 1;
+    memmove(dest, dest - 1, edit_field->buffer_size - edit_field->cursor);
 
     edit_field->buffer[edit_field->cursor++] = c;
     edit_field->buffer[++edit_field->buffer_size] = 0;
@@ -138,9 +138,8 @@ static void delete_char(Edit_field *edit_field)
         return;
     }
 
-    for (size_t i = edit_field->cursor; i < edit_field->buffer_size; ++i) {
-        edit_field->buffer[i] = edit_field->buffer[i + 1];
-    }
+    char *dest = edit_field->buffer + edit_field->cursor;
+    memmove(dest, dest + 1, edit_field->buffer_size - edit_field->cursor - 1);
 
     edit_field->buffer[--edit_field->buffer_size] = 0;
 }
@@ -152,9 +151,8 @@ static void delete_backward_char(Edit_field *edit_field)
         return;
     }
 
-    for (size_t i = edit_field->cursor; i < edit_field->buffer_size; ++i) {
-        edit_field->buffer[i - 1] = edit_field->buffer[i];
-    }
+    char *dest = edit_field->buffer + edit_field->cursor - 1;
+    memmove(dest, dest + 1, edit_field->buffer_size - edit_field->cursor);
 
     edit_field->cursor--;
     edit_field->buffer[--edit_field->buffer_size] = 0;

--- a/src/ui/edit_field.c
+++ b/src/ui/edit_field.c
@@ -59,17 +59,12 @@ static void edit_field_insert_char(Edit_field *edit_field, char c)
 
 static bool is_emacs_word(char c)
 {
-#define IN_RANGE(start, end) (c >= start && c <= end)
-
     // Word syntax table retrieved from Fundamental Mode, "C-h s"
     // (This is not the complete syntax table)
-    return IN_RANGE('$', '%')
-        || IN_RANGE('0', '9')
-        || IN_RANGE('A', 'Z')
-        || IN_RANGE('a', 'z')
-        ;
-
-#undef IN_RANGE
+    return (c >= '$' && c <= '%')
+        || (c >= '0' && c <= '9')
+        || (c >= 'A' && c <= 'Z')
+        || (c >= 'a' && c <= 'z');
 }
 
 static void forward_char(Edit_field *edit_field)
@@ -193,29 +188,29 @@ static void backward_kill_word(Edit_field *edit_field)
 static void handle_keydown(Edit_field *edit_field, const SDL_Event *event)
 {
     switch (event->key.keysym.sym) {
-    case SDLK_HOME:
+    case SDLK_HOME: {
         move_beginning_of_line(edit_field);
-        break;
+    } break;
 
-    case SDLK_END:
+    case SDLK_END: {
         move_end_of_line(edit_field);
-        break;
+    } break;
 
-    case SDLK_BACKSPACE:
+    case SDLK_BACKSPACE: {
         delete_backward_char(edit_field);
-        break;
+    } break;
 
-    case SDLK_DELETE:
+    case SDLK_DELETE: {
         delete_char(edit_field);
-        break;
+    } break;
 
-    case SDLK_RIGHT:
+    case SDLK_RIGHT: {
         forward_char(edit_field);
-        break;
+    } break;
 
-    case SDLK_LEFT:
+    case SDLK_LEFT: {
         backward_char(edit_field);
-        break;
+    } break;
     }
 }
 
@@ -223,64 +218,64 @@ static void handle_keydown_alt(Edit_field *edit_field, const SDL_Event *event)
 {
     switch (event->key.keysym.sym) {
     case SDLK_BACKSPACE:
-    case SDLK_DELETE:
+    case SDLK_DELETE: {
         backward_kill_word(edit_field);
-        break;
+    } break;
 
     case SDLK_RIGHT:
-    case SDLK_f:
+    case SDLK_f: {
         forward_word(edit_field);
-        break;
+    } break;
 
     case SDLK_LEFT:
-    case SDLK_b:
+    case SDLK_b: {
         backward_word(edit_field);
-        break;
+    } break;
 
-    case SDLK_d:
+    case SDLK_d: {
         kill_word(edit_field);
-        break;
+    } break;
     }
 }
 
 static void handle_keydown_ctrl(Edit_field *edit_field, const SDL_Event *event)
 {
     switch (event->key.keysym.sym) {
-    case SDLK_BACKSPACE:
+    case SDLK_BACKSPACE: {
         backward_kill_word(edit_field);
-        break;
+    } break;
 
-    case SDLK_DELETE:
+    case SDLK_DELETE: {
         kill_word(edit_field);
-        break;
+    } break;
 
-    case SDLK_RIGHT:
+    case SDLK_RIGHT: {
         forward_word(edit_field);
-        break;
+    } break;
 
-    case SDLK_LEFT:
+    case SDLK_LEFT: {
         backward_word(edit_field);
-        break;
+    } break;
 
-    case SDLK_a:
+    case SDLK_a: {
         move_beginning_of_line(edit_field);
-        break;
+    } break;
 
-    case SDLK_e:
+    case SDLK_e: {
         move_end_of_line(edit_field);
-        break;
+    } break;
 
-    case SDLK_f:
+    case SDLK_f: {
         forward_char(edit_field);
-        break;
+    } break;
 
-    case SDLK_b:
+    case SDLK_b: {
         backward_char(edit_field);
-        break;
+    } break;
 
-    case SDLK_d:
+    case SDLK_d: {
         delete_char(edit_field);
-        break;
+    } break;
     }
 }
 

--- a/src/ui/edit_field.c
+++ b/src/ui/edit_field.c
@@ -20,13 +20,269 @@ struct Edit_field
     Color font_color;
 };
 
-static void edit_field_left(Edit_field *edit_field);
-static void edit_field_right(Edit_field *edit_field);
-static void edit_field_home(Edit_field *edit_field);
-static void edit_field_end(Edit_field *edit_field);
-static void edit_field_backspace(Edit_field *edit_field);
-static void edit_field_delete(Edit_field *edit_field);
 static void edit_field_insert_char(Edit_field *edit_field, char c);
+
+// See: https://www.gnu.org/software/emacs/manual/html_node/emacs/Moving-Point.html
+// For an explanation of the naming terminology for these helper methods
+static bool is_emacs_word(char c);
+static void forward_char(Edit_field *edit_field);
+static void backward_char(Edit_field *edit_field);
+static void move_beginning_of_line(Edit_field *edit_field);
+static void move_end_of_line(Edit_field *edit_field);
+static void forward_word(Edit_field *edit_field);
+static void backward_word(Edit_field *edit_field);
+static void delete_char(Edit_field *edit_field);
+static void delete_backward_char(Edit_field *edit_field);
+static void kill_word(Edit_field *edit_field);
+static void backward_kill_word(Edit_field *edit_field);
+
+static void handle_keydown(Edit_field *edit_field, const SDL_Event *event);
+static void handle_keydown_alt(Edit_field *edit_field, const SDL_Event *event);
+static void handle_keydown_ctrl(Edit_field *edit_field, const SDL_Event *event);
+
+static void edit_field_insert_char(Edit_field *edit_field, char c)
+{
+    if (edit_field->buffer_size >= BUFFER_CAPACITY) {
+        return;
+    }
+
+    for (int64_t i = (int64_t) edit_field->buffer_size - 1; i >= (int64_t) edit_field->cursor; --i) {
+        edit_field->buffer[i + 1] = edit_field->buffer[i];
+    }
+
+    edit_field->buffer[edit_field->cursor++] = c;
+    edit_field->buffer[++edit_field->buffer_size] = 0;
+}
+
+// See: https://www.gnu.org/software/emacs/manual/html_node/emacs/Moving-Point.html
+// For an explanation of the naming terminology for these helper methods
+
+static bool is_emacs_word(char c)
+{
+#define IN_RANGE(start, end) (c >= start && c <= end)
+
+    // Word syntax table retrieved from Fundamental Mode, "C-h s"
+    // (This is not the complete syntax table)
+    return IN_RANGE('$', '%')
+        || IN_RANGE('0', '9')
+        || IN_RANGE('A', 'Z')
+        || IN_RANGE('a', 'z')
+        ;
+
+#undef IN_RANGE
+}
+
+static void forward_char(Edit_field *edit_field)
+{
+    // "C-f" or "<RIGHT>"
+    if (edit_field->cursor < edit_field->buffer_size) {
+        edit_field->cursor++;
+    }
+}
+
+static void backward_char(Edit_field *edit_field)
+{
+    // "C-b" or "<LEFT>"
+    if (edit_field->cursor > 0) {
+        edit_field->cursor--;
+    }
+}
+
+static void move_beginning_of_line(Edit_field *edit_field)
+{
+    // "C-a" or "<Home>"
+    edit_field->cursor = 0;
+}
+
+static void move_end_of_line(Edit_field *edit_field)
+{
+    // "C-e" or "<End>"
+    edit_field->cursor = edit_field->buffer_size;
+}
+
+static void forward_word(Edit_field *edit_field)
+{
+    // "M-f" or "C-<RIGHT>" or "M-<RIGHT>"
+    while (true) {
+        forward_char(edit_field);
+        if (edit_field->cursor >= edit_field->buffer_size) {
+            break;
+        }
+
+        char current = edit_field->buffer[edit_field->cursor];
+        char preceeding = edit_field->buffer[edit_field->cursor - 1];
+        if (!is_emacs_word(current) && is_emacs_word(preceeding)) {
+            // Reached the end of the current word
+            break;
+        }
+    }
+}
+
+static void backward_word(Edit_field *edit_field)
+{
+    // "M-b" or "C-<LEFT>" or "M-<LEFT>"
+    while (true) {
+        backward_char(edit_field);
+        if (edit_field->cursor == 0) {
+            break;
+        }
+
+        char current = edit_field->buffer[edit_field->cursor];
+        char preceeding = edit_field->buffer[edit_field->cursor - 1];
+        if (is_emacs_word(current) && !is_emacs_word(preceeding)) {
+            // Reached the start of the current word
+            break;
+        }
+    }
+}
+
+static void delete_char(Edit_field *edit_field)
+{
+    // "C-d" or "<Delete>"
+    if (edit_field->cursor >= edit_field->buffer_size) {
+        return;
+    }
+
+    for (size_t i = edit_field->cursor; i < edit_field->buffer_size; ++i) {
+        edit_field->buffer[i] = edit_field->buffer[i + 1];
+    }
+
+    edit_field->buffer[--edit_field->buffer_size] = 0;
+}
+
+static void delete_backward_char(Edit_field *edit_field)
+{
+    // "<BACKSPACE>"
+    if (edit_field->cursor == 0) {
+        return;
+    }
+
+    for (size_t i = edit_field->cursor; i < edit_field->buffer_size; ++i) {
+        edit_field->buffer[i - 1] = edit_field->buffer[i];
+    }
+
+    edit_field->cursor--;
+    edit_field->buffer[--edit_field->buffer_size] = 0;
+}
+
+static void kill_word(Edit_field *edit_field)
+{
+    // "M-d" or "C-<Delete>"
+    size_t start = edit_field->cursor;
+    forward_word(edit_field);
+    size_t end = edit_field->cursor;
+    edit_field->cursor = start;
+
+    for (size_t i = start; i < end; ++i) {
+        delete_char(edit_field);
+    }
+}
+
+static void backward_kill_word(Edit_field *edit_field)
+{
+    // "M-<BACKSPACE>" or "C-<BACKSPACE>" or "M-<Delete>"
+    size_t end = edit_field->cursor;
+    backward_word(edit_field);
+    size_t start = edit_field->cursor;
+
+    for (size_t i = start; i < end; ++i) {
+        delete_char(edit_field);
+    }
+}
+
+static void handle_keydown(Edit_field *edit_field, const SDL_Event *event)
+{
+    switch (event->key.keysym.sym) {
+    case SDLK_HOME:
+        move_beginning_of_line(edit_field);
+        break;
+
+    case SDLK_END:
+        move_end_of_line(edit_field);
+        break;
+
+    case SDLK_BACKSPACE:
+        delete_backward_char(edit_field);
+        break;
+
+    case SDLK_DELETE:
+        delete_char(edit_field);
+        break;
+
+    case SDLK_RIGHT:
+        forward_char(edit_field);
+        break;
+
+    case SDLK_LEFT:
+        backward_char(edit_field);
+        break;
+    }
+}
+
+static void handle_keydown_alt(Edit_field *edit_field, const SDL_Event *event)
+{
+    switch (event->key.keysym.sym) {
+    case SDLK_BACKSPACE:
+    case SDLK_DELETE:
+        backward_kill_word(edit_field);
+        break;
+
+    case SDLK_RIGHT:
+    case SDLK_f:
+        forward_word(edit_field);
+        break;
+
+    case SDLK_LEFT:
+    case SDLK_b:
+        backward_word(edit_field);
+        break;
+
+    case SDLK_d:
+        kill_word(edit_field);
+        break;
+    }
+}
+
+static void handle_keydown_ctrl(Edit_field *edit_field, const SDL_Event *event)
+{
+    switch (event->key.keysym.sym) {
+    case SDLK_BACKSPACE:
+        backward_kill_word(edit_field);
+        break;
+
+    case SDLK_DELETE:
+        kill_word(edit_field);
+        break;
+
+    case SDLK_RIGHT:
+        forward_word(edit_field);
+        break;
+
+    case SDLK_LEFT:
+        backward_word(edit_field);
+        break;
+
+    case SDLK_a:
+        move_beginning_of_line(edit_field);
+        break;
+
+    case SDLK_e:
+        move_end_of_line(edit_field);
+        break;
+
+    case SDLK_f:
+        forward_char(edit_field);
+        break;
+
+    case SDLK_b:
+        backward_char(edit_field);
+        break;
+
+    case SDLK_d:
+        delete_char(edit_field);
+        break;
+    }
+}
 
 Edit_field *create_edit_field(Vec font_size,
                               Color font_color)
@@ -125,94 +381,42 @@ int edit_field_render_world(const Edit_field *edit_field,
     return 0;
 }
 
+int edit_field_event(Edit_field *edit_field, const SDL_Event *event)
+{
+    trace_assert(edit_field);
+    trace_assert(event);
+
+    switch (event->type) {
+    case SDL_KEYDOWN: {
+        if (event->key.keysym.mod & KMOD_ALT) {
+            handle_keydown_alt(edit_field, event);
+        } else if (event->key.keysym.mod & KMOD_CTRL) {
+            handle_keydown_ctrl(edit_field, event);
+        } else {
+            handle_keydown(edit_field, event);
+        }
+    } break;
+
+    case SDL_TEXTINPUT: {
+        if ((SDL_GetModState() & (KMOD_CTRL | KMOD_ALT))) {
+            // Don't process text input if a modifier key is held
+            break;
+        }
+
+        size_t n = strlen(event->text.text);
+        for (size_t i = 0; i < n; ++i) {
+            edit_field_insert_char(edit_field, event->text.text[i]);
+        }
+    } break;
+    }
+
+    return 0;
+}
+
 const char *edit_field_as_text(const Edit_field *edit_field)
 {
     trace_assert(edit_field);
     return edit_field->buffer;
-}
-
-static void edit_field_left(Edit_field *edit_field)
-{
-    trace_assert(edit_field);
-    if (edit_field->cursor > 0) {
-        edit_field->cursor--;
-    }
-}
-
-static void edit_field_home(Edit_field *edit_field)
-{
-    trace_assert(edit_field);
-    edit_field->cursor = 0;
-}
-
-static void edit_field_end(Edit_field *edit_field)
-{
-    trace_assert(edit_field);
-    edit_field->cursor  = edit_field->buffer_size;
-}
-
-static void edit_field_right(Edit_field *edit_field)
-{
-    trace_assert(edit_field);
-    if (edit_field->cursor < edit_field->buffer_size) {
-        edit_field->cursor++;
-    }
-}
-
-static void edit_field_backspace(Edit_field *edit_field)
-{
-    trace_assert(edit_field);
-
-    if (edit_field->cursor == 0) {
-        return;
-    }
-
-    for (size_t i = edit_field->cursor; i < edit_field->buffer_size; ++i) {
-        edit_field->buffer[i - 1] = edit_field->buffer[i];
-    }
-
-    edit_field->cursor--;
-    edit_field->buffer[--edit_field->buffer_size] = 0;
-}
-
-static void edit_field_delete(Edit_field *edit_field)
-{
-    trace_assert(edit_field);
-
-    if (edit_field->cursor >= edit_field->buffer_size) {
-        return;
-    }
-
-    for (size_t i = edit_field->cursor; i < edit_field->buffer_size; ++i) {
-        edit_field->buffer[i] = edit_field->buffer[i + 1];
-    }
-
-    edit_field->buffer[--edit_field->buffer_size] = 0;
-}
-
-static void edit_field_insert_char(Edit_field *edit_field, char c)
-{
-    trace_assert(edit_field);
-
-    if (edit_field->buffer_size >= BUFFER_CAPACITY) {
-        return;
-    }
-
-    for (int64_t i = (int64_t) edit_field->buffer_size - 1; i >= (int64_t) edit_field->cursor; --i) {
-        edit_field->buffer[i + 1] = edit_field->buffer[i];
-    }
-
-    edit_field->buffer[edit_field->cursor++] = c;
-    edit_field->buffer[++edit_field->buffer_size] = 0;
-}
-
-void edit_field_clean(Edit_field *edit_field)
-{
-    trace_assert(edit_field);
-
-    edit_field->cursor = 0;
-    edit_field->buffer_size = 0;
-    edit_field->buffer[0] = 0;
 }
 
 void edit_field_replace(Edit_field *edit_field, const char *text)
@@ -231,49 +435,13 @@ void edit_field_replace(Edit_field *edit_field, const char *text)
     }
 }
 
-int edit_field_event(Edit_field *edit_field, const SDL_Event *event)
+void edit_field_clean(Edit_field *edit_field)
 {
     trace_assert(edit_field);
-    trace_assert(event);
 
-    switch (event->type) {
-    case SDL_KEYDOWN: {
-        switch (event->key.keysym.sym) {
-        case SDLK_LEFT:
-            edit_field_left(edit_field);
-            break;
-
-        case SDLK_RIGHT:
-            edit_field_right(edit_field);
-            break;
-
-        case SDLK_HOME:
-            edit_field_home(edit_field);
-            break;
-
-        case SDLK_END:
-            edit_field_end(edit_field);
-            break;
-
-        case SDLK_BACKSPACE:
-            edit_field_backspace(edit_field);
-            break;
-
-        case SDLK_DELETE:
-            edit_field_delete(edit_field);
-            break;
-        }
-    } break;
-
-    case SDL_TEXTINPUT: {
-        size_t n = strlen(event->text.text);
-        for (size_t i = 0; i < n; ++i) {
-            edit_field_insert_char(edit_field, event->text.text[i]);
-        }
-    } break;
-    }
-
-    return 0;
+    edit_field->cursor = 0;
+    edit_field->buffer_size = 0;
+    edit_field->buffer[0] = 0;
 }
 
 void edit_field_restyle(Edit_field *edit_field,


### PR DESCRIPTION
Adds the most common Emacs keybindings to the console.

`static` helper methods are named according to the GNU Emacs
terminology:
https://www.gnu.org/software/emacs/manual/html_node/emacs/Moving-Point.html
