### PR TITLE
Added threshold to joystick axis

### DIFF
--- a/src/game/level.c
+++ b/src/game/level.c
@@ -30,6 +30,7 @@
 #include "game/level/script.h"
 
 #define LEVEL_GRAVITY 1500.0f
+#define JOYSTICK_THRESHOLD 1000
 
 struct Level
 {
@@ -274,9 +275,9 @@ int level_input(Level *level,
         player_move_left(level->player);
     } else if (keyboard_state[SDL_SCANCODE_D]) {
         player_move_right(level->player);
-    } else if (the_stick_of_joy && SDL_JoystickGetAxis(the_stick_of_joy, 0) < 0) {
+    } else if (the_stick_of_joy && SDL_JoystickGetAxis(the_stick_of_joy, 0) < -JOYSTICK_THRESHOLD) {
         player_move_left(level->player);
-    } else if (the_stick_of_joy && SDL_JoystickGetAxis(the_stick_of_joy, 0) > 0) {
+    } else if (the_stick_of_joy && SDL_JoystickGetAxis(the_stick_of_joy, 0) > JOYSTICK_THRESHOLD) {
         player_move_right(level->player);
     } else {
         player_stop(level->player);


### PR DESCRIPTION
Please test this with your controller before merging!

When i tried playing nothing with my X-Box controller, the player just moved to left until i pushed the stick to the right.

Mainstream game engines like unity have a threshold, until a joystick movement is considered to be a real movement, so i added this here aswell. The value is kinda arbitrary though.
If you have a better solution or you don't care, feel free to ignore this, but for me the game was hard to play