### PR TITLE
Explicitly set numeric locale to "C". Fixes tsoding/nothing#1019

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #include <SDL.h>
 
+#include <locale.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -58,6 +59,8 @@ int main(int argc, char *argv[])
         RETURN_LT(lt, -1);
     }
     PUSH_LT(lt, 42, SDL_Quit);
+
+    setlocale(LC_NUMERIC, "C");
 
     SDL_ShowCursor(SDL_DISABLE);
 


### PR DESCRIPTION
SDL_Init sets current locale to system locale, which alters default floating-point format and results in level definition parsing failure due to invalid floating point value format.

I wasn't quite sure how to address this, since SDL changes the locale, there probably is a good reason for that. I've considered changing locale to "C" everywhere where we do (f|s)scanf and then set it back, but not sure if it is a reliable method. For now, changing specifically `LC_NUMERIC` should suffice, IMO.