### PR TITLE
Prevent writing too much

### DIFF
--- a/src/game/level/level_editor/point_layer.c
+++ b/src/game/level/level_editor/point_layer.c
@@ -513,8 +513,9 @@ int point_layer_edit_id_event(PointLayer *point_layer,
 
             char *id = dynarray_pointer_at(point_layer->ids, (size_t) point_layer->selected);
             const char *text = edit_field_as_text(point_layer->edit_field);
-            memset(id, 0, ID_MAX_SIZE);
-            memcpy(id, text, min_size_t(strlen(text), ID_MAX_SIZE - 1));
+            size_t n = min_size_t(strlen(text), ID_MAX_SIZE - 1);
+            memcpy(id, text, n);
+            memset(id + n, 0, ID_MAX_SIZE - n);
 
             point_layer->state = POINT_LAYER_IDLE;
             SDL_StopTextInput();


### PR DESCRIPTION
Little optimization.

Doesn't overwrite everything with 0s.