### PR TITLE
removed wandering player on console bug

### DIFF
--- a/src/game/level.c
+++ b/src/game/level.c
@@ -395,7 +395,7 @@ int level_input(Level *level,
     trace_assert(level);
     trace_assert(keyboard_state);
 
-    if (level->state == LEVEL_STATE_PAUSE) {
+    if (level->state == LEVEL_STATE_PAUSE || level->state == LEVEL_STATE_CONSOLE) {
         return 0;
     }
 


### PR DESCRIPTION
The player was wandering around when user type A or D on the console.
This might be problematic as the player can go to dangerous area when
they using the console