### PR TITLE
Fix sscanf checking in rect_layer.c

### DIFF
--- a/src/game/level/level_editor/rect_layer.c
+++ b/src/game/level/level_editor/rect_layer.c
@@ -707,7 +707,7 @@ RectLayer *create_rect_layer_from_line_stream(LineStream *line_stream, const cha
                    id,
                    &rect.x, &rect.y,
                    &rect.w, &rect.h,
-                   hex, &n) == EOF) {
+                   hex, &n) <= 0) {
             log_fail("%s\n", strerror(errno));
             RETURN_LT(layer->lt, NULL);
         }
@@ -720,14 +720,14 @@ RectLayer *create_rect_layer_from_line_stream(LineStream *line_stream, const cha
 
         Action action = {0};
 
-        if (sscanf(line, "%d%n", (int*)&action.type, &n) != EOF) {
+        if (sscanf(line, "%d%n", (int*)&action.type, &n) > 0) {
             line += n;
             switch (action.type) {
             case ACTION_NONE: break;
 
             case ACTION_TOGGLE_GOAL:
             case ACTION_HIDE_LABEL: {
-                if (sscanf(line, "%"STRINGIFY(ENTITY_MAX_ID_SIZE)"s", action.entity_id) == EOF) {
+                if (sscanf(line, "%"STRINGIFY(ENTITY_MAX_ID_SIZE)"s", action.entity_id) <= 0) {
                     log_fail("%s\n", strerror(errno));
                     RETURN_LT(layer->lt, NULL);
                 }
@@ -958,7 +958,7 @@ int rect_layer_dump_stream(const RectLayer *layer, FILE *filedump)
 
         case ACTION_TOGGLE_GOAL:
         case ACTION_HIDE_LABEL: {
-            fprintf(filedump, " %d %.*s ",
+            fprintf(filedump, " %d %.*s",
                     (int)actions[i].type,
                     ENTITY_MAX_ID_SIZE, actions[i].entity_id);
         } break;


### PR DESCRIPTION
So I couldn't really let this go after last night's stream LMAO. I put some comments on the relevant lines.

1. make sscanf checking in rect_layer.c more robust
2. remove trailing whitespace on saving level

Some explanation:
Let's say there's `const char* str = "abc def ghi\n";` If we do `sscanf(str, "%d%d%d", ...)`, then obviously it will fail, because `abc` is not a `%d`. However, in this instance `sscanf` will return `0` instead of `-1` (aka `EOF`), because it started to perform conversions, but failed to perform any.

On the other hand, let's say instead `const char* str = "        \n";`. When we attempt a `sscanf`, it will return `-1` (aka `EOF`) this time, because it did not find any non-whitespace chars to perform conversions.

So there's a potential issue; if the line in the `level.txt` was non-empty but contained garbage which doesn't fit the format, then the values in `rect` will be unspecified (because it wasn't initialised).

see: https://godbolt.org/z/ZPer6f