### PR TITLE
Symlink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(nothing)
 
 if(WIN32)
@@ -158,6 +158,9 @@ add_executable(nothing
   src/game/level/level_editor/action_picker.c
 )
 target_link_libraries(nothing ${SDL2_LIBRARIES} system)
+
+ADD_CUSTOM_TARGET(link_assets ALL
+                  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/assets ${CMAKE_BINARY_DIR}/assets)
 
 if(("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang"))
   set(CMAKE_C_FLAGS

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
           }
        } else {
            bash -c "sudo apt-get update -qq"
-           bash -c "sudo apt-get install -qq cmake cmake-data libsdl2-dev libxml2-dev"
+           bash -c "sudo apt-get install -qq libsdl2-dev libxml2-dev"
        }
 build_script:
   - mkdir build

--- a/src/game.c
+++ b/src/game.c
@@ -66,7 +66,7 @@ Game *create_game(const char *level_folder,
     game->font = PUSH_LT(
         lt,
         create_sprite_font_from_file(
-            "images/charmap-oldschool.bmp",
+            "./assets/images/charmap-oldschool.bmp",
             renderer),
         destroy_sprite_font);
     if (game->font == NULL) {
@@ -96,7 +96,7 @@ Game *create_game(const char *level_folder,
     game->renderer = renderer;
     game->texture_cursor = PUSH_LT(
         lt,
-        texture_from_bmp("images/cursor.bmp", renderer),
+        texture_from_bmp("./assets/images/cursor.bmp", renderer),
         SDL_DestroyTexture);
     if (SDL_SetTextureBlendMode(
             game->texture_cursor,

--- a/src/main.c
+++ b/src/main.c
@@ -115,18 +115,18 @@ int main(int argc, char *argv[])
     // ------------------------------
 
     const char * sound_sample_files[] = {
-        "./sounds/nothing.wav",
-        "./sounds/something.wav",
-        "./sounds/dev/ding.wav",
-        "./sounds/dev/click.wav",
-        "./sounds/dev/save.wav"
+        "./assets/sounds/nothing.wav",
+        "./assets/sounds/something.wav",
+        "./assets/sounds/dev/ding.wav",
+        "./assets/sounds/dev/click.wav",
+        "./assets/sounds/dev/save.wav"
     };
     const size_t sound_sample_files_count = sizeof(sound_sample_files) / sizeof(char*);
 
     Game *const game = PUSH_LT(
         lt,
         create_game(
-            "./levels/",
+            "./assets/levels/",
             sound_sample_files,
             sound_sample_files_count,
             renderer),


### PR DESCRIPTION
With this PR, the game should be ran directly on the build directory, without the 
```
$ cd ../assets/
$ ../build/nothing
```
hack to run it.

---

The symlink command is fixed for Windows with CMake version 3.13, more information at https://cmake.org/cmake/help/v3.13/release/3.13.html#command-line, https://gitlab.kitware.com/cmake/cmake/merge_requests/2144,  and 
https://gitlab.kitware.com/cmake/cmake/issues/13162