### PR TITLE
(#974) Support non-1x display resolution scale

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -26,4 +26,7 @@ int game_over_check(const Game *game);
 
 int game_load_level(Game *game, const char *filepath);
 
+// defined in main.c. is there a better place for this to be declared?
+float get_display_scale(void);
+
 #endif  // GAME_H_

--- a/src/game/level/level_editor/rect_layer.c
+++ b/src/game/level/level_editor/rect_layer.c
@@ -1207,7 +1207,7 @@ int rect_layer_event(RectLayer *layer,
     switch (event->type) {
     case SDL_WINDOWEVENT: {
         switch (event->window.event) {
-        case SDL_WINDOWEVENT_RESIZED: {
+        case SDL_WINDOWEVENT_SIZE_CHANGED: {
             grid_relayout(layer->grid, rect(0.0f, 0.0f,
                                             (float) event->window.data1,
                                             (float) event->window.data2));

--- a/src/game/level_picker.c
+++ b/src/game/level_picker.c
@@ -152,12 +152,12 @@ int level_picker_event(LevelPicker *level_picker,
     case SDL_WINDOWEVENT: {
         switch (event->window.event) {
         case SDL_WINDOWEVENT_SHOWN:
-        case SDL_WINDOWEVENT_RESIZED: {
+        case SDL_WINDOWEVENT_SIZE_CHANGED: {
             const Vec2f font_scale = vec(5.0f, 5.0f);
             const float padding_bottom = 50.0f;
 
             int width;
-            SDL_GetWindowSize(SDL_GetWindowFromID(event->window.windowID), &width, NULL);
+            SDL_GetRendererOutputSize(SDL_GetRenderer(SDL_GetWindowFromID(event->window.windowID)), &width, NULL);
 
             const Vec2f title_size = wiggly_text_size(&level_picker->wiggly_text, camera);
 

--- a/src/main.c
+++ b/src/main.c
@@ -62,10 +62,6 @@ void maybe_fixup_input_for_display_scale(SDL_Window* win, SDL_Renderer* rend, SD
         }
     } break;
 
-    // early-out.
-    if (current_display_scale == 1.0f)
-        return;
-
     // this is the fixup.
     case SDL_MOUSEMOTION: {
         // note: do it this way *just in case* there are non-integer display scales out there.

--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,6 @@ void recalculate_display_scale(SDL_Window* win, SDL_Renderer* rend)
     SDL_GetRendererOutputSize(rend, &w1, NULL);
 
     current_display_scale = (float) w1 / (float) w0;
-    log_info("Current display scale: %.1f\n", current_display_scale);
 }
 
 static

--- a/src/main.c
+++ b/src/main.c
@@ -64,14 +64,15 @@ void maybe_fixup_input_for_display_scale(SDL_Window* win, SDL_Renderer* rend, SD
 
     // this is the fixup.
     case SDL_MOUSEMOTION: {
-        e->motion.x *= current_display_scale;
-        e->motion.y *= current_display_scale;
+        // note: do it this way *just in case* there are non-integer display scales out there.
+        e->motion.x = (int) ((float) e->motion.x * current_display_scale);
+        e->motion.y = (int) ((float) e->motion.y * current_display_scale);
     } break;
 
     case SDL_MOUSEBUTTONUP:
     case SDL_MOUSEBUTTONDOWN: {
-        e->button.x *= current_display_scale;
-        e->button.y *= current_display_scale;
+        e->button.x = (int) ((float) e->button.x * current_display_scale);
+        e->button.y = (int) ((float) e->button.y * current_display_scale);
     } break;
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -62,6 +62,10 @@ void maybe_fixup_input_for_display_scale(SDL_Window* win, SDL_Renderer* rend, SD
         }
     } break;
 
+    // early-out.
+    if (current_display_scale == 1.0f)
+        return;
+
     // this is the fixup.
     case SDL_MOUSEMOTION: {
         // note: do it this way *just in case* there are non-integer display scales out there.

--- a/src/main.c
+++ b/src/main.c
@@ -38,23 +38,12 @@ static
 void recalculate_display_scale(SDL_Window* win, SDL_Renderer* rend)
 {
     int w0 = 0;
-    int h0 = 0;
-    SDL_GetWindowSize(win, &w0, &h0);
+    SDL_GetWindowSize(win, &w0, NULL);
 
     int w1 = 0;
-    int h1 = 0;
-    SDL_GetRendererOutputSize(rend, &w1, &h1);
+    SDL_GetRendererOutputSize(rend, &w1, NULL);
 
-    float x_scale = (float) w1 / (float) w0;
-    float y_scale = (float) h1 / (float) h0;
-
-    if (x_scale != y_scale) {
-        log_fail("inconsistent dpi scale: horz: %.1f, vert: %.1f\n", x_scale, y_scale);
-    }
-
-    // if x_scale == y_scale then it doesn't matter either way. simplifies code.
-    // anyway fmax is cheap right?
-    current_display_scale = fmaxf(x_scale, y_scale);
+    current_display_scale = (float) w1 / (float) w0;
     log_info("Current display scale: %.1f\n", current_display_scale);
 }
 

--- a/src/ui/cursor.c
+++ b/src/ui/cursor.c
@@ -9,8 +9,8 @@ int cursor_render(const Cursor *cursor, SDL_Renderer *renderer)
 
     int cursor_x, cursor_y;
     SDL_GetMouseState(&cursor_x, &cursor_y);
-    cursor_x *= get_display_scale();
-    cursor_y *= get_display_scale();
+    cursor_x = (int) ((float) cursor_x * get_display_scale());
+    cursor_y = (int) ((float) cursor_y * get_display_scale());
 
     const SDL_Rect src = {0, 0, CURSOR_ICON_WIDTH, CURSOR_ICON_HEIGHT};
     const SDL_Rect dest = {

--- a/src/ui/cursor.c
+++ b/src/ui/cursor.c
@@ -1,5 +1,6 @@
 #include "system/stacktrace.h"
 #include "cursor.h"
+#include "game.h"
 
 int cursor_render(const Cursor *cursor, SDL_Renderer *renderer)
 {
@@ -8,6 +9,8 @@ int cursor_render(const Cursor *cursor, SDL_Renderer *renderer)
 
     int cursor_x, cursor_y;
     SDL_GetMouseState(&cursor_x, &cursor_y);
+    cursor_x *= get_display_scale();
+    cursor_y *= get_display_scale();
 
     const SDL_Rect src = {0, 0, CURSOR_ICON_WIDTH, CURSOR_ICON_HEIGHT};
     const SDL_Rect dest = {


### PR DESCRIPTION
As the title suggests; closes #974.

Overview of changes:
1. Pass `SDL_WINDOW_ALLOW_HIGHDPI` to `SDL_CreateWindow` to give us a high-resolution-capable window context with OpenGL or whoever
2. Introduce notion of `display_scale`, which is the size in physical pixels divided by the size in logical pixels. macbook retina displays are scaled at 2x, for example.
3. Hook `WINDOW_SIZE_CHANGED` and `WINDOW_MOVED` events and recalculate the display scale. (if you're wondering why on move as well, the game may be moved to another monitor with different scale).
4. Most importantly, at the top-level event loop (before any other subsystem/layer gets the events), hijack mouse events and scale the `x` and `y` values by the display scale. This keeps everybody happy because nobody needs to manually get the scale and multiply before using. I think this is the cleanest and most elegant solution.

Couple of other stuff:
1. Fixed the positioning of the level picker, it now uses the scaled pixel width to get the centre of the screen.
2. Cursor rendering needs to explicitly scale as well.
3. Added a `get_display_scale()` function which might be useful for other people in the future. For now I put the declaration in `game.h`, but if there's a better place let me know.
4. Also, changed the use of `WINDOWEVENT_RESIZED`to `WINDOWEVENT_SIZE_CHANGED`. According to documention (https://wiki.libsdl.org/SDL_WindowEventID), `SIZE_CHANGED` is always sent, even when window is changed by API call or something. Probably more flexible than resize only.


@rexim pls test on normal screens uwu