### PR TITLE
(#1193) Add option to go back to level picker from the level

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -464,18 +464,22 @@ int game_event(Game *game, const SDL_Event *event)
             } break;
             }
         } break;
+        case SDL_KEYDOWN: {
+            switch (event->key.keysym.sym) {
+            case SDLK_ESCAPE: {
+                if (game->state == GAME_STATE_LEVEL) {
+                    game_switch_state(game, GAME_STATE_LEVEL_PICKER);
+                }
+            } break;
+            }
+        } break;
         }
     }
 
     // State event handling
     switch (game->state) {
-    case GAME_STATE_LEVEL: {
-        if (event->key.keysym.sym == SDLK_ESCAPE) {
-            game_switch_state(game, GAME_STATE_LEVEL_PICKER);
-            return 0;
-        }
+    case GAME_STATE_LEVEL:
         return game_event_running(game, event);
-    }
 
     case GAME_STATE_LEVEL_PICKER:
         return game_event_level_picker(game, event);

--- a/src/game.c
+++ b/src/game.c
@@ -19,14 +19,6 @@
 #include "game/settings.h"
 #include "game/credits.h"
 
-typedef enum Game_state {
-    GAME_STATE_LEVEL = 0,
-    GAME_STATE_LEVEL_PICKER,
-    GAME_STATE_LEVEL_EDITOR,
-    GAME_STATE_CREDITS,
-    GAME_STATE_SETTINGS,
-    GAME_STATE_QUIT
-} Game_state;
 
 typedef struct Game {
     Lt *lt;
@@ -46,7 +38,6 @@ typedef struct Game {
     int console_enabled;
 } Game;
 
-static
 void game_switch_state(Game *game, Game_state state)
 {
     game->camera = create_camera(game->renderer, game->font);
@@ -368,7 +359,6 @@ static int game_event_level_picker(Game *game, const SDL_Event *event)
                 return -1;
             }
 
-            level_picker_clean_selection(game->level_picker);
             game_switch_state(game, GAME_STATE_LEVEL);
         } break;
 
@@ -458,15 +448,6 @@ int game_event(Game *game, const SDL_Event *event)
                     SDL_StartTextInput();
                     game->console_enabled = 1;
                     console_slide_down(game->console);
-                }
-            } break;
-            }
-        } break;
-        case SDL_KEYDOWN: {
-            switch (event->key.keysym.sym) {
-            case SDLK_ESCAPE: {
-                if (game->state == GAME_STATE_LEVEL) {
-                    game_switch_state(game, GAME_STATE_LEVEL_PICKER);
                 }
             } break;
             }
@@ -594,7 +575,6 @@ int game_load_level(Game *game, const char *level_filename)
         return -1;
     }
 
-    level_picker_clean_selection(game->level_picker);
     game_switch_state(game, GAME_STATE_LEVEL);
 
     return 0;

--- a/src/game.c
+++ b/src/game.c
@@ -368,6 +368,7 @@ static int game_event_level_picker(Game *game, const SDL_Event *event)
                 return -1;
             }
 
+            level_picker_clean_selection(game->level_picker);
             game_switch_state(game, GAME_STATE_LEVEL);
         } break;
 
@@ -402,6 +403,8 @@ static int game_event_level_editor(Game *game, const SDL_Event *event)
             if (game->level == NULL) {
                 return -1;
             }
+
+            level_picker_clean_selection(game->level_picker);
             game_switch_state(game, GAME_STATE_LEVEL);
         } break;
         }
@@ -466,8 +469,13 @@ int game_event(Game *game, const SDL_Event *event)
 
     // State event handling
     switch (game->state) {
-    case GAME_STATE_LEVEL:
+    case GAME_STATE_LEVEL: {
+        if (event->key.keysym.sym == SDLK_ESCAPE) {
+            game_switch_state(game, GAME_STATE_LEVEL_PICKER);
+            return 0;
+        }
         return game_event_running(game, event);
+    }
 
     case GAME_STATE_LEVEL_PICKER:
         return game_event_level_picker(game, event);
@@ -584,6 +592,7 @@ int game_load_level(Game *game, const char *level_filename)
         return -1;
     }
 
+    level_picker_clean_selection(game->level_picker);
     game_switch_state(game, GAME_STATE_LEVEL);
 
     return 0;

--- a/src/game.c
+++ b/src/game.c
@@ -403,8 +403,6 @@ static int game_event_level_editor(Game *game, const SDL_Event *event)
             if (game->level == NULL) {
                 return -1;
             }
-
-            level_picker_clean_selection(game->level_picker);
             game_switch_state(game, GAME_STATE_LEVEL);
         } break;
         }

--- a/src/game.c
+++ b/src/game.c
@@ -40,6 +40,9 @@ typedef struct Game {
 
 void game_switch_state(Game *game, Game_state state)
 {
+    if (state == GAME_STATE_LEVEL_PICKER) {
+        level_picker_clean_selection(game->level_picker);
+    }
     game->camera = create_camera(game->renderer, game->font);
     game->state = state;
 }

--- a/src/game.h
+++ b/src/game.h
@@ -24,6 +24,16 @@ int game_input(Game *game,
 
 int game_over_check(const Game *game);
 
+typedef enum Game_state {
+    GAME_STATE_LEVEL = 0,
+    GAME_STATE_LEVEL_PICKER,
+    GAME_STATE_LEVEL_EDITOR,
+    GAME_STATE_CREDITS,
+    GAME_STATE_SETTINGS,
+    GAME_STATE_QUIT
+} Game_state;
+
+void game_switch_state(Game *game, Game_state state);
 int game_load_level(Game *game, const char *filepath);
 
 // defined in main.c. is there a better place for this to be declared?

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -170,6 +170,10 @@ static int console_eval_input(Console *console)
         if (game_load_level(console->game, level_name) < 0) {
             console_log_push_line(console->console_log, "Could not load level", NULL, CONSOLE_ERROR);
         }
+    } else if (token_equals_str(command, "menu")) {
+        console_log_push_line(console->console_log, "Loading menu", NULL, CONSOLE_FOREGROUND);
+        level_picker_clean_selection(console->game->level_picker);
+        game_switch_state(console->game, GAME_STATE_LEVEL_PICKER);
     } else {
         console_log_push_line(console->console_log, "Unknown command", NULL, CONSOLE_ERROR);
     }

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -172,7 +172,6 @@ static int console_eval_input(Console *console)
         }
     } else if (token_equals_str(command, "menu")) {
         console_log_push_line(console->console_log, "Loading menu", NULL, CONSOLE_FOREGROUND);
-        level_picker_clean_selection(console->game->level_picker);
         game_switch_state(console->game, GAME_STATE_LEVEL_PICKER);
     } else {
         console_log_push_line(console->console_log, "Unknown command", NULL, CONSOLE_ERROR);


### PR DESCRIPTION
This PR is going to resolve #1193 
### Steps to check:
1. Run the game
1. Select any level
1. Open console
1. Type 'menu' and press enter to go back to level picker