### PR TITLE
(#1173) Set metadata title to filename when saving

### DIFF
--- a/src/game/level/level_editor.c
+++ b/src/game/level/level_editor.c
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include <string.h>
 
 #include "game/camera.h"
 #include "game/sound_samples.h"
@@ -398,6 +399,8 @@ int level_editor_saveas_event(LevelEditor *level_editor,
                 level_editor->lt,
                 string_duplicate(path, NULL),
                 free);
+            strcpy(level_editor->metadata.title,
+                edit_field_as_text(level_editor->edit_field_filename));
             level_editor_dump(level_editor);
             SDL_StopTextInput();
             level_editor->state = LEVEL_EDITOR_IDLE;


### PR DESCRIPTION
Fix #1173 