### PR TITLE
Workaround for successfull build on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,8 +165,11 @@ add_executable(nothing
 )
 target_link_libraries(nothing ${SDL2_LIBRARIES})
 
-ADD_CUSTOM_TARGET(link_assets ALL
-                  COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/assets ${CMAKE_BINARY_DIR}/assets)
+if(WIN32)
+    ADD_CUSTOM_TARGET(link_assets ALL COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/assets ${CMAKE_BINARY_DIR}/assets)
+else()
+    ADD_CUSTOM_TARGET(link_assets ALL COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/assets ${CMAKE_BINARY_DIR}/assets)
+endif()
 
 if(("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang") OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang"))
   set(CMAKE_C_FLAGS


### PR DESCRIPTION
According to the current instructions to build the project on Windows with MSVC you have to run the following command in the Developer Command Prompt  : 
> cmake --build .

If you dont have Administrator rights you will obtain an error like this : 
CUSTOMBUILD : CMake error : failed to create symbolic link 'D:/DATA/PROGETTI/2019/nothing_test/build/assets': operation not permitted

This happen because on Windows the cmake instructions "-E create_symlink" can be execute only with Administrator privileges.

This proposed change try to obtain the most similar behaviour using instead the command  "-E copy_directory" that is allowed also for non Adminitrators users