### PR TITLE
Update macOS virtual environment on Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           NOTHING_CI: on
 
   build-macos:
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v1
       - name: install dependencies


### PR DESCRIPTION
Currently used macOS-10.14 virtual environment image is deprecated by Github: https://github.blog/changelog/2019-10-31-github-actions-macos-virtual-environment-is-updating-to-catalina-and-dropping-mojave-support/
They recommend to use latest one. And also they emailed that builds on macOS-10.14 are going to fail after January 15th.