### PR TITLE
Remove vec_mag in favor of vec_length (Fixes #1256)

### DIFF
--- a/src/math/vec.h
+++ b/src/math/vec.h
@@ -59,12 +59,6 @@ float vec_arg(Vec2f v)
 }
 
 static inline
-float vec_mag(Vec2f v)
-{
-    return sqrtf(v.x * v.x + v.y * v.y);
-}
-
-static inline
 Vec2f vec_sum(Vec2f v1, Vec2f v2)
 {
     Vec2f result = {


### PR DESCRIPTION
vec_mag wasn't used anyway.

This does not make the binary any smaller since the functions are inline anyway, it just cleans up the source.